### PR TITLE
mitgliederhandbuch aktualisiert

### DIFF
--- a/mitgliederhandbuch.tex
+++ b/mitgliederhandbuch.tex
@@ -144,7 +144,7 @@ Im IRC kannst du herausfinden, ob das RaumZeitLabor gerade offen ist, indem du
 den Befehl \texttt{!raum} schickst. Du kannst die Rundumleuchte im Raum
 aktivieren um die Anwesenden auf deine Nachrichten im IRC hinzuweisen, indem du
 \texttt{!ping} schickst. Wenn Du hinter \texttt{!ping} noch eine Nachricht
-hängt, so wird diese auf dem LCD-Display über der Tafel im Raum angezeigt.
+hängst, so wird diese auf dem LCD-Display über der Tafel im Raum angezeigt.
 \np
 
 Zusätzlich gibt es die Möglichkeit herauszufinden, welche Laboranten gerade im
@@ -176,10 +176,10 @@ dienstägliche Programm verwaltet.
 
 \section*{Blog}
 
-Auf \url{https://raumzeitlabor.de/blog} schreiben wir über alle möglichen
+Auf \url{https://raumzeitlabor.de/blog/} schreiben wir über alle möglichen
 Neuigkeiten aus dem RaumZeitLabor. Viele Menschen lesen das Blog und daher wäre
 es gut, wenn du neue Beiträge beisteuern könntest -- zum Beispiel, wenn ein
 Projekt Fortschritte macht. Forke dazu das
-\href{https://github.com/raumzeitlabor/rzl-homepage/}{Repositoy} vom Blog,
+\href{https://github.com/raumzeitlabor/rzl-homepage/}{Repositoy} des Blogs,
 verfasse den Blogpost und erstelle einen Pullrequest.
 \end{document}

--- a/mitgliederhandbuch.tex
+++ b/mitgliederhandbuch.tex
@@ -28,7 +28,7 @@
 \pagestyle{fancy}
 \lhead{RZL}
 \chead{Mitgliederhandbuch}
-\rhead{2012-12-17}
+\rhead{2017-01-18}
 \newcommand{\np}{\bigskip\noindent}
 \setlength{\parindent}{0pt}
 
@@ -54,7 +54,7 @@ Alles Wissenswerte erfährst du in den folgenden Abschnitten.
 Als Mitglied erhältst du eine PIN, mit der du die Tür zum RaumZeitLabor
 aufschließen kannst. Melde dich dazu -- möglichst mit deinem echten Namen, um
 dem Vorstand die Zuordnung zu erleichtern -- in der
-\href{https://raumzeitlabor.de/BenutzerDB/register}{BenutzerDB} an. Danach
+\href{https://benutzerdb.raumzeitlabor.de/BenutzerDB/register}{BenutzerDB} an. Danach
 kannst Du den Vorstand bitten, dir eine PIN zuzuteilen. Hierzu benötigen sie
 deinen Benutzernamen.
 
@@ -77,7 +77,7 @@ Jeden ersten Sonntag im Monat halten wir ein Plenum. Das Plenum ist ein
 öffentliches Treffen von Mitgliedern (und denen die es werden wollen), auf dem
 wir aktuelle Themen besprechen und kleinere Entscheidungen treffen können. Die
 zu besprechenden Punkte sammeln wir im Wiki auf der Seite
-\href{https://raumzeitlabor.de/wiki/Plenum}{``Plenum''}. Wenn Du Ideen hast, wie
+\href{https://wiki.raumzeitlabor.de/wiki/Plenum}{``Plenum''}. Wenn Du Ideen hast, wie
 wir das Zusammenleben im Verein verbessern können, oder dir Dinge aufgefallen
 sind, die dir nicht gepasst haben, trage diese einfach auf der Seite ein. Auf
 dem Plenum ist dann die Gelegenheit, in Ruhe darüber zu reden, und
@@ -86,7 +86,7 @@ Anschaffungen. \np
 
 ``Wo gehobelt wird fallen Späne'' -- so natürlich auch bei uns. Deswegen treffen
 wir uns \emph{vor} dem Plenum, um den Raum auf Vordermann zu bringen
-(\href{https://raumzeitlabor.de/wiki/Wipe_\%26_Defrag}{``Wipe \& Defrag''});
+(\href{https://wiki.raumzeitlabor.de/wiki/Wipe_\%26_Defrag}{``Wipe \& Defrag''});
 üblicherweise gegen 14 bis 15 Uhr. Jeder schnappt sich einen Besen, Kehrblech,
 Staubsauger oder Wischmob und gibt sein Bestes. Natürlich möchten wir niemanden
 zwingen, zum Putzen auftauchen -- wenn Du allerdings häufig da bist, würden wir
@@ -114,7 +114,7 @@ dass du den Internetanschluss für P2P benutzt!}
 
 Es gibt eine Mailingliste für das RaumZeitLabor, welche Interessierte abonniert
 haben:\\
-\url{http://lists.raumzeitlabor.de/mailman/private/raumzeitlabor/}
+\url{https://lists.raumzeitlabor.de/mailman/private/raumzeitlabor/}
 \np
 
 Auf dieser Mailingliste findest du oftmals Ankündigungen und generelle
@@ -122,20 +122,16 @@ Mitteilungen zu allen möglichen Themen. Auch kann es schon einmal hoch her
 gehen; sei aber unbesorgt, in der Regel verstehen wir uns alle sehr gut.
 \np
 
-Zusätzlich zur ``Haupt''-Mailingliste gibt es auch noch ``info'' sowie
-``announce''. Erstere wird als Kontaktadresse auf unseren Seiten verwendet,
-damit Anfragen möglichst schnell von den entsprechenden Leuten beantwortet
-werden können (möglicherweise also auch von dir!). ``announce'' wird -- wie der
-Name bereits sagt -- für öffentliche Ankündigungen verwendet. Hier solltest Du
-nur etwas schreiben, wenn Du ein Event von dir ankündigen möchtest. Auch
-solltest Du die essentiellen Informationen bereits im Kalender eingetragen
-haben.
+Zusätzlich zur ``Haupt''-Mailingliste gibt es auch noch ``info''. Diese wird als
+Kontaktadresse auf unseren Seiten verwendet, damit Anfragen möglichst schnell
+von den entsprechenden Leuten beantwortet werden können (möglicherweise also
+auch von dir!).
 
 \section*{Wiki}
 
 In unserem Wiki findet sich Dokumentation zu allem, was sich im RaumZeitLabor
 an Equipment befindet (wenn nicht, ergänze es!):
-\url{https://raumzeitlabor.de/wiki}
+\url{https://wiki.raumzeitlabor.de/}
 
 \section*{Internet Relay Chat (IRC)}
 
@@ -148,24 +144,20 @@ Im IRC kannst du herausfinden, ob das RaumZeitLabor gerade offen ist, indem du
 den Befehl \texttt{!raum} schickst. Du kannst die Rundumleuchte im Raum
 aktivieren um die Anwesenden auf deine Nachrichten im IRC hinzuweisen, indem du
 \texttt{!ping} schickst. Wenn Du hinter \texttt{!ping} noch eine Nachricht
-hängt, so wird diese auf dem LED-Display im Raum angezeigt. Anwesende
-Laboranten können dir dann aus ein paar vorgegebenen Antwortmöglichkeiten eine
-Antwort zukommen lassen.
+hängt, so wird diese auf dem LCD-Display über der Tafel im Raum angezeigt.
 \np
 
 Zusätzlich gibt es die Möglichkeit herauszufinden, welche Laboranten gerade im
-Raum sind. Hierfür gibt es den Befehl \texttt{!weristda}. Der Statusbot
-antwortet dir dann mit einer Liste der Mitglieder, deren Geräte in unserem
-Netzwerk erreichbar sind. Voraussetzung hierfür ist, dass das jeweilige
-Mitglied die MAC-Adressen seiner Geräte in der BenutzerDB eingetragen hat (und
-das ist natürlich freiwillig).
+Raum sind. Alle anwesenden Laboranten haben Voice (\texttt{+v}). Voraussetzung
+hierfür ist, dass das jeweilige Mitglied die MAC-Adressen seiner Geräte in der
+BenutzerDB eingetragen hat (und das ist natürlich freiwillig).
 
 \section*{Sourcecode und Projektdateien: Github}
 
 Für Versionskontrolle verwenden wir überwiegend
-git\footnote{\url{http://www.git-scm.com/}} und hosten unsere git-repositories
-auf \href{http://github.com/}{github} unter der Adresse
-\url{http://github.com/raumzeitlabor}. Du kannst ein neues Repository anlegen,
+git\footnote{\url{https://www.git-scm.com/}} und hosten unsere git-repositories
+auf \href{https://github.com/}{github} unter der Adresse
+\url{https://github.com/raumzeitlabor}. Du kannst ein neues Repository anlegen,
 indem du dich an einen der Administratoren auf github wendest, derzeit sind das
 u.a.\ tiefpunkt, Felicitus und Else.
 
@@ -184,11 +176,10 @@ dienstägliche Programm verwaltet.
 
 \section*{Blog}
 
-Auf \url{http://raumzeitlabor.de/blog} schreiben wir über alle möglichen
+Auf \url{https://raumzeitlabor.de/blog} schreiben wir über alle möglichen
 Neuigkeiten aus dem RaumZeitLabor. Viele Menschen lesen das Blog und daher wäre
 es gut, wenn du neue Beiträge beisteuern könntest -- zum Beispiel, wenn ein
-Projekt Fortschritte macht. Melde dich dazu auf \url{http://raumzeitlabor.de/}
-an und wende dich an Inte, silsha oder Else um fürs Bloggen freigeschaltet zu
-werden.
-
+Projekt Fortschritte macht. Forke dazu das
+\href{https://github.com/raumzeitlabor/rzl-homepage/}{Repositoy} vom Blog,
+verfasse den Blogpost und erstelle einen Pullrequest.
 \end{document}


### PR DESCRIPTION
s/http/https
announce@ wurde das letzte mal 2015-08-09 von ThinkJDs Dienstagsankündigungsmail verwendet → weg
Ping hat leider keinen Rückkanal (RL→irc) mehr → weg
kein Bot fühlt sich für !weristda zuständig. Statt dessen hat halt jeder Anwesende +v
Kurzfassung zum Erzeugen von Blogposts aktualisiert